### PR TITLE
修改seaweedfs在删除文件过程中的调用错误

### DIFF
--- a/weedfs_fs.go
+++ b/weedfs_fs.go
@@ -410,15 +410,11 @@ func (this *weedclient) DoDelete(path string) error {
 	if err != nil {
 		return err
 	}
-
 	defer rsp.Body.Close()
-	b, err := ioutil.ReadAll(rsp.Body)
-	if err != nil {
-		return err
-	}
 
 	var info VolumeInfo
-	err = json.Unmarshal(b, &info)
+	dec := json.NewDecoder(rsp.Body)
+	err = dec.Decode(&info)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
seaweedfs删除文件,先向master获取特定volumeId所在的volume server的地址,然后向指定的volume server发送删除文件请求